### PR TITLE
Fix Docker Compose hot reload for development

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,8 @@ services:
     environment:
       - PORT=${PORT:-8080}
       - FLASK_DEBUG=${FLASK_DEBUG:-true}
+      - FLASK_ENV=development
+    command: ["python", "main.py"]
     develop:
       watch:
         - action: sync
@@ -18,3 +20,5 @@ services:
             - .venv/
         - action: rebuild
           path: ./uv.lock
+        - action: rebuild
+          path: ./pyproject.toml


### PR DESCRIPTION
## Summary
- Fix Docker Compose watch mode not applying changes during development
- Switch from Gunicorn to Flask development server for hot reload
- Add proper Flask development environment configuration

## Changes
- Added `FLASK_ENV=development` environment variable
- Changed command from Gunicorn to `python main.py` for development
- Added rebuild trigger for `pyproject.toml` changes
- Maintained existing sync configuration for file watching

## Test plan
- [ ] Run `just dev` and verify server starts in development mode
- [ ] Modify `main.py` and confirm changes are automatically detected and applied
- [ ] Verify Flask debug mode is active with detailed error pages
- [ ] Test that dependency changes trigger container rebuild

🤖 Generated with [Claude Code](https://claude.ai/code)